### PR TITLE
fix overflow of output

### DIFF
--- a/style.css
+++ b/style.css
@@ -25,7 +25,7 @@ body {
 .output {
 	background-color: #b5bab4;
 	color: #2e3638;
-	padding: 5px;
+	padding: 10px;
 	font-size: 2rem;
 	width: 100%;
 	height: 80px;
@@ -39,6 +39,7 @@ body {
 	align-items: center;
 	letter-spacing: 0.2rem;
 	word-break: break-all;
+	overflow: hidden;
 }
 
 .calculator-buttons {


### PR DESCRIPTION
User can type any length of number but it wouldn't overshoot the output space provided. Used overflow:hidden 